### PR TITLE
fail tests if test failure detected

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -30,7 +30,9 @@ else
 fi
 
 
-export NWCHEM_MODULES="all python"
+#export NWCHEM_MODULES="all python"
+# testing...
+export NWCHEM_MODULES="nwdft solvation driver"
 #faster build
 #export NWCHEM_MODULES="nwdft driver solvation hessian property vib"
 export NWCHEM_LONG_PATHS=y

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -30,9 +30,7 @@ else
 fi
 
 
-#export NWCHEM_MODULES="all python"
-# testing...
-export NWCHEM_MODULES="nwdft solvation driver"
+export NWCHEM_MODULES="all python"
 #faster build
 #export NWCHEM_MODULES="nwdft driver solvation hessian property vib"
 export NWCHEM_LONG_PATHS=y

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - make_config.patch
 
 build:
-  number: 1
+  number: 2
   skip: True  # [win]
 
 requirements:

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -14,4 +14,6 @@ export MPIRUN_PATH=$PREFIX/bin/mpirun
 export NWCHEM_BASIS_LIBRARY=$SRC_DIR/src/basis/libraries/
 
 cd $NWCHEM_TOP/QA
-./doafewqmtests.mpi 2
+./doafewqmtests.mpi 2 | tee tests.log
+# fail if one of the tests failed
+! grep "NWChem execution failed" tests.log || exit 1


### PR DESCRIPTION
fix #9 

the nwchem test script only fails if the very last test fails.
we want the CI build to fail if *any* of the tests failed.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
