### PR TITLE
set nwchem env vars upon activation

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -93,20 +93,9 @@ EOF
 mkdir -p "$PREFIX/etc/conda/activate.d/" "$PREFIX/etc/conda/deactivate.d/"
 
 cat > "$PREFIX/etc/conda/activate.d/nwchem_env.sh" << "EOF"
-if [ ! -f $HOME/.nwchemrc ]; then
-    ln -s $CONDA_PREFIX/etc/default.nwchemrc $HOME/.nwchemrc
-	touch $HOME/.CONDANWCHEMRC
-fi
+export NWCHEM_BASIS_LIBRARY=$CONDA_PREFIX/share/nwchem/libraries/
+export NWCHEM_NWPW_LIBRARY=$CONDA_PREFIX/share/nwchem/libraryps/
 EOF
 cat > "$PREFIX/etc/conda/activate.d/nwchem_env.fish" << "EOF"
     bash $CONDA_PREFIX/etc/conda/activate.d/nwchem_env.sh
-EOF
-
-cat > "$PREFIX/etc/conda/deactivate.d/nwchem_env.sh" << "EOF"
-if [ -f $HOME/.CONDANWCHEMRC ]; then
-    rm $HOME/.CONDANWCHEMRC $HOME/.nwchemrc
-fi
-EOF
-cat > "$PREFIX/etc/conda/deactivate.d/nwchem_env.fish" << "EOF"
-    bash $CONDA_PREFIX/etc/conda/deactivate.d/nwchem_env.sh
 EOF

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - make_config.patch
 
 build:
-  number: 2
+  number: 3
   skip: True  # [win]
 
 requirements:

--- a/recipe/post-link.sh
+++ b/recipe/post-link.sh
@@ -1,0 +1,7 @@
+
+#!/bin/bash
+
+echo " " >> $PREFIX/.messages.txt
+echo "Before starting to use nwchem please deactivate and activate your environment again." >> $PREFIX/.messages.txt
+echo "This will correctly populate the NWCHEM_BASIS_LIBRARY and NWCHEM_NWPW_LIBRARY environment variables." >> $PREFIX/.messages.txt
+echo "For a more extensive configuration, copy the $PREFIX/etc/default.nwchemrc file to ~/.nwchemrc." >> $PREFIX/.messages.txt


### PR DESCRIPTION
fix #6

don't automatically copy the .nwchemrc file

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
