### PR TITLE
reduce size of test files

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,9 +36,37 @@ requirements:
       - python
 
 test:
+    # note: test files are included in the conda package
+    # avoid shipping more than necessary (test suite is large!)
     source_files:
-      - QA
-      - src/basis/libraries
+      - QA/run*
+      - QA/do*
+      - QA/tests/h2o_opt
+      - QA/tests/dft_he2+
+      - QA/tests/small_intchk
+      - QA/tests/h2o_dk
+      - QA/tests/cosmo_h2o_dft
+      - QA/tests/pyqa3
+      - QA/tests/tddft_h2o
+      - QA/tests/tddft_n2+
+      - QA/tests/tddft_ac_co
+      - QA/tests/hi_zora_sf
+      - QA/tests/prop_ch3f
+      - QA/tests/h2_bnl
+      - QA/tests/h2o_bnl
+      - QA/tests/h2o-camb3lyp-pol
+      - QA/tests/h2o-cambeckehh
+      - QA/tests/h2o-campbe0
+      - QA/tests/h2o-lcpbe
+      - QA/tests/o2_bnl
+      - QA/tests/o2_hfattn
+      - QA/tests/dmo_tddft_cd
+      - QA/tests/dmo_tddft_cd_velocity
+      - QA/tests/h2o-response
+      - QA/tests/h2o2-response
+      - QA/tests/h2o2-response-uhf
+      - QA/tests/h2o2-response-uhf-damping
+      - QA/tests/h2o2-prop-notrans
     requires:
       - perl
 

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -11,8 +11,12 @@ export NWCHEM_TARGET=""
 export MPIRUN_PATH=$PREFIX/bin/mpirun 
 # nwchem cannot deal with path lengths >255 characters
 #export NWCHEM_BASIS_LIBRARY=$PREFIX/share/nwchem/libraries/
-cp -r $PREFIX/share/nwchem/libraries/ $SRC_DIR
-export NWCHEM_BASIS_LIBRARY=$SRC_DIR/libraries
+mkdir -p $SRC_DIR/src/basis
+ln -s $PREFIX/share/nwchem/libraries/ $SRC_DIR/src/basis/libraries
+# not sure this env var actually has any effect
+# (the tests may be looking for the libraries at a relative location)
+export NWCHEM_BASIS_LIBRARY=$SRC_DIR/src/basis/libraries/
+
 
 cd $NWCHEM_TOP/QA
 ./doafewqmtests.mpi 2 | tee tests.log

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -11,7 +11,8 @@ export NWCHEM_TARGET=""
 export MPIRUN_PATH=$PREFIX/bin/mpirun 
 # nwchem cannot deal with path lengths >255 characters
 #export NWCHEM_BASIS_LIBRARY=$PREFIX/share/nwchem/libraries/
-export NWCHEM_BASIS_LIBRARY=$SRC_DIR/src/basis/libraries/
+cp -r $PREFIX/share/nwchem/libraries/ $SRC_DIR
+export NWCHEM_BASIS_LIBRARY=$SRC_DIR/libraries
 
 cd $NWCHEM_TOP/QA
 ./doafewqmtests.mpi 2 | tee tests.log


### PR DESCRIPTION
fix #8 

The conda package ships all source files needed for running the tests.
Since the test suite is large (>500MB) we want to ship only those tests
that are actually necessary.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
