### PR TITLE
patch to load $CONDA_PREFIX/etc/default.nwchemrc for MM

### DIFF
--- a/recipe/conda_nwchemrc.patch
+++ b/recipe/conda_nwchemrc.patch
@@ -1,0 +1,14 @@
+diff --git a/src/util/util_nwchemrc.F b/src/util/util_nwchemrc.F
+index cabafa4c76..11a6abbfe4 100644
+--- a/src/util/util_nwchemrc.F
++++ b/src/util/util_nwchemrc.F
+@@ -113,6 +113,9 @@ c
+           nwchrc=home(1:inp_strlen(home))//'/.nwchemrc '
+         elseif (ipass.eq.3) then
+           nwchrc="/etc/nwchemrc"
++        else if (ipass.eq.4) then
++          call util_getenv('CONDA_PREFIX',home)
++          nwchrc=home(1:inp_strlen(home))//'/etc/default.nwchemrc '
+         else
+           return
+         endif

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,6 +28,7 @@ source:
     - earlyexit.patch
     - qalargemem.patch
     - tblite.patch
+    - conda_nwchemrc.patch
   
 build:
   number: {{ build }} 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -4,7 +4,7 @@
 {% set date = "2023-03-10" %}
 
 {% set armci_network = armci_network or 'mpi_ts' %}
-{% set build = 6 %}
+{% set build = 7 %}
 {% if armci_network  == 'mpi_ts' %}
 # prioritize 'nompi' variant via build number
 {% set build = build + 1000 %}


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

added patch to load `$CONDA_PREFIX/etc/default.nwchemrc` for MM. 
This makes the command  `cp $CONDA_PREFIX/etc/default.nwchemrc $HOME/.nwchemrc` obsolete
<!--
Please add any other relevant info below:
-->
